### PR TITLE
Small k8s improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM percona/percona-xtradb-cluster:5.7.25
 
+USER root
+RUN rm /var/log/mysqld.log && \
+	ln -s /dev/stdout /var/log/mysqld.log \
+	&& chown mysql:mysql /var/log/mysqld.log
+
 COPY entrypoint.sh /entrypoint.sh
 COPY functions.sh /functions.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM percona/percona-xtradb-cluster:5.7.19
+FROM percona/percona-xtradb-cluster:5.7.25
 
 COPY entrypoint.sh /entrypoint.sh
 COPY functions.sh /functions.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,7 @@ if [[ -z "${cluster_join}" ]]; then
     --wsrep_node_address="$ipaddr" $CMDARG
 else
   echo "I am not the Primary Node"
+  chown -R mysql:mysql /var/lib/mysql
   write_password_file
   exec mysqld --user=mysql --wsrep_cluster_name=$CLUSTER_NAME --wsrep_node_name=$hostname \
     --wsrep_cluster_address="gcomm://$cluster_join" --wsrep_sst_method=xtrabackup-v2 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,10 @@ if [ "${1:0:1}" = '-' ]; then
 	CMDARG="$@"
 fi
 
+[ -f /var/log/mysqld.log ] && rm /var/log/mysqld.log
+ln -s /dev/stdout /var/log/mysqld.log
+chown mysql:mysql /var/log/mysqld.log
+
 cluster_join=$(resolveip -s "${K8S_SERVICE_NAME}" || echo "")
 if [[ -z "${cluster_join}" ]]; then
   echo "I am the Primary Node"

--- a/functions.sh
+++ b/functions.sh
@@ -29,8 +29,6 @@ if [ ! -e "$DATADIR/mysql" ]; then
 	echo "Running --initialize-insecure on $DATADIR"
 	ls -lah $DATADIR
 	mysqld --initialize-insecure
-	chown -R mysql:mysql "$DATADIR"
-	chown mysql:mysql /var/log/mysqld.log
 	echo 'Finished --initialize-insecure'
 
 	mysqld --user=mysql --datadir="$DATADIR" --skip-networking &


### PR DESCRIPTION
Thanks so much for figuring this out. Its really fixed a problem I was struggling with. I've encountered two small issues while running this inside the Google Compute Engine:

1) mysqld isn't logging to stdout
This makes "kubectl logs -f percona-galera-0" a lot less useful. The first patch tricks mysqld into writing everything to /dev/stdout via a symlink that has write permissions for the mysql user.

2) Volume permission issue
I'm using volumeClaimTemplates to give my pods persistent storage. These volumes come up owned by root. The init_mysql function fixes permissions for the Primary, but it was missed for all the non-primaries.